### PR TITLE
Set owner of config

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,8 @@
   ansible.builtin.template:
     src: config.php.j2
     dest: "{{ moodle_httpd_data_directory }}/moodle/config.php"
+    owner: "{{ moodle_httpd_owner }}"
+    group: "{{ moodle_httpd_group }}"
     mode: "0640"
 
 - name: Setup cron job


### PR DESCRIPTION
```bash
root@moodle:/var/www/html/moodle# ls -la
-rwxr-xr-x  1 www-data www-data  60901 Jan 20 01:41 config-dist.php
-rw-r-----  1 root     root        736 Jan 25 22:14 config.php
drwxr-xr-x  7 www-data www-data     12 Jan 20 01:41 contentbank
```

```bash
$ cat /var/log/apache2/error.log 
PHP Fatal error:  Uncaught Error: Failed opening required 'config.php' (include_path='.:/usr/share/php') in /var/www/html/moodle/index.php:30\nStack trace:\n#0 {main}\n  thrown in /var/www/html/moodle/index.php on line 30
[Wed Jan 25 22:17:30.879460 2023] [php:warn] [pid 491] [client 10.0.103.2:51810] PHP Warning:  Undefined property: stdClass::$lang in /var/www/html/moodle/lib/weblib.php on line 2248
```