### PR TITLE
mbstring missing

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,4 +14,4 @@ exclude_paths:
   - ./requirements.yml
 
 warn_list:
-  - jinja
+  - jinja[spacing]  # TODO: Rule that looks inside jinja2 templates

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -35,10 +35,10 @@ jobs:
         uses: buluma/molecule-action@v5.0.4
         with:
           command: lint
-  test:
+  molecule_test:
     needs:
       - lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,6 +9,7 @@ _moodle_requirements:
     - php-intl
     - php-xmlrpc
     - php-soap
+    - php-mbstring
   RedHat-8:
     - php-mysqlnd
     - php-zip
@@ -16,6 +17,7 @@ _moodle_requirements:
     - php-intl
     - php-xmlrpc
     - php-soap
+    - php-mbstring
   Debian:
     - php-mysqli
     - php-zip
@@ -23,12 +25,14 @@ _moodle_requirements:
     - php-intl
     - php-xmlrpc
     - php-soap
+    - php-mbstring
   Debian-testing:
     - php-mysql
     - php-zip
     - php-gd
     - php-intl
     - php-soap
+    - php-mbstring
   Suse:
     - php7-mysql
     - php7-zip


### PR DESCRIPTION
moodle401 on ubuntu 22.04 (php 8.1.2)
```
[Wed Jan 25 22:17:30.882611 2023] [php:error] [pid 491] [client 10.0.103.2:51810] PHP Fatal error:  Uncaught Error: Call to undefined function mb_list_encodings() in /var/www/html/moodle/lib/classes/text.php:60\nStack trace:\n#0 /var/www/html/moodle/lib/classes/text.php(251): core_text::is_charset_supported()\n#1 /var/www/html/moodle/lib/classes/collator.php(231): core_text::strtolower()\n#2 /var/www/html/moodle/lib/classes/string_manager_standard.php(577): core_collator::asort()\n#3 /var/www/html/moodle/lib/classes/string_manager_standard.php(511): core_string_manager_standard->get_list_of_translations()\n#4 /var/www/html/moodle/lib/weblib.php(2248): core_string_manager_standard->translation_exists()\n#5 /var/www/html/moodle/lib/setuplib.php(2146): get_html_lang()\n#6 /var/www/html/moodle/lib/setuplib.php(2092): bootstrap_renderer::plain_page()\n#7 /var/www/html/moodle/lib/setuplib.php(370): bootstrap_renderer::early_error()\n#8 [internal function]: default_exception_handler()\n#9 {main}\n  thrown in /var/www/html/moodle/lib/classes/text.php on line 60
```